### PR TITLE
[bugfix] THREE.BufferGeometry Runtime Error

### DIFF
--- a/src/components/canvas/Stars.jsx
+++ b/src/components/canvas/Stars.jsx
@@ -5,7 +5,7 @@ import * as random from "maath/random/dist/maath-random.esm";
 
 const Stars = (props) => {
   const ref = useRef();
-  const [sphere] = useState(() => random.inSphere(new Float32Array(5000), { radius: 1.2 }));
+  const [sphere] = useState(() => random.inSphere(new Float32Array(5001), { radius: 1.2 }));
 
   useFrame((state, delta) => {
     ref.current.rotation.x -= delta / 10;


### PR DESCRIPTION
Issue: 
- `Stars.jxs` throws runtime error
- Sphere array should have a length divisible by 3. The threejs vector takes 3 points (x, y, z) from the array so a length of 5000 would leave a missing z point  

![Screen Shot 2023-05-13 at 9 11 33 PM](https://github.com/ladunjexa/Threejs-3D-Portfolio/assets/25694146/49f2cc18-395d-4cac-9b3a-65d25ac7a5f6)

Issue: 

References:
- https://github.com/adrianhajdin/project_3D_developer_portfolio/issues/7
- https://stackoverflow.com/a/75838722