### PR TITLE
Fix inconsistent ServiceCard width on mobile view

### DIFF
--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -22,7 +22,7 @@ const ServiceCard: React.FC<IServiceCard> = ({ index, title, icon }) => (
     tiltMaxAngleY={30}
     glareColor="#aaa6c3"
   >
-    <div className="w-[250px]">
+    <div className="max-w-[250px] w-full xs:w-[250px]">
       <motion.div
         variants={fadeIn("right", "spring", index * 0.5, 0.75)}
         className="green-pink-gradient shadow-card w-full rounded-[20px] p-[1px]"

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -22,7 +22,7 @@ const ServiceCard: React.FC<IServiceCard> = ({ index, title, icon }) => (
     tiltMaxAngleY={30}
     glareColor="#aaa6c3"
   >
-    <div className="xs:w-[250px] w-full">
+    <div className="w-[250px]">
       <motion.div
         variants={fadeIn("right", "spring", index * 0.5, 0.75)}
         className="green-pink-gradient shadow-card w-full rounded-[20px] p-[1px]"


### PR DESCRIPTION
Device: iPhone 13

Previously:
- Card widths on mobile view were inconsistent, causing a misaligned and uneven layout.

![reactjs18-3d-portfolio](https://github.com/user-attachments/assets/31c6885f-3b93-4469-bf21-a1be1340ed55)


Now:
- Card widths are consistent across mobile view, providing a uniform and cleaner layout.

![reactjs18-3d-portfolio_2](https://github.com/user-attachments/assets/3a73b196-6379-4c18-9eec-00c627ffa067)
